### PR TITLE
feat: allow late initialization of OneWayMarketTemplate

### DIFF
--- a/src/constants/utils.ts
+++ b/src/constants/utils.ts
@@ -1,33 +1,4 @@
-import {IDict, ILlamma} from "../interfaces";
+import {IDict} from "../interfaces";
 
-export const lowerCaseLlammasAddresses = (llammas: IDict<ILlamma>): IDict<ILlamma> => {
-    for (const llammaId in llammas) {
-        if (!Object.prototype.hasOwnProperty.call(llammas, llammaId)) continue;
-        const llamma = llammas[llammaId];
-        llamma.amm_address = llamma.amm_address.toLowerCase();
-        llamma.controller_address = llamma.controller_address.toLowerCase();
-        llamma.collateral_address = llamma.collateral_address.toLowerCase();
-        llamma.monetary_policy_address = llamma.monetary_policy_address.toLowerCase();
-        llamma.leverage_zap = llamma.leverage_zap.toLowerCase();
-    }
-
-    return llammas
-}
-
-export const extractDecimals = (llammas: IDict<ILlamma>): IDict<number> => {
-    const DECIMALS: IDict<number> = {};
-    for (const llammaId in llammas) {
-        if (!Object.prototype.hasOwnProperty.call(llammas, llammaId)) continue;
-        const llamma = llammas[llammaId];
-
-        // Collateral
-        DECIMALS[llamma.collateral_address] = llamma.collateral_decimals;
-    }
-
-    return DECIMALS
-}
-
-export const lowerCaseValues = (dict: IDict<string>): IDict<string> => {
-    // @ts-ignore
-    return Object.fromEntries(Object.entries(dict).map((entry) => [entry[0], entry[1].toLowerCase()]))
-}
+export const lowerCaseValues = (dict: IDict<string>): IDict<string> =>
+    Object.fromEntries(Object.entries(dict).map((entry) => [entry[0], entry[1].toLowerCase()]))

--- a/src/lending.ts
+++ b/src/lending.ts
@@ -525,7 +525,7 @@ class Lending implements ILending {
         }
 
         amms.forEach((amm: string, index: number) => {
-            this.setContract(amms[index], LlammaABI);
+            this.setContract(amm, LlammaABI);
             this.setContract(controllers[index], ControllerABI);
             this.setContract(monetary_policies[index], MonetaryPolicyABI);
             this.setContract(vaults[index], VaultABI);

--- a/src/markets/MarketConstructor.ts
+++ b/src/markets/MarketConstructor.ts
@@ -1,5 +1,7 @@
 import { OneWayMarketTemplate} from "./OneWayMarketTemplate.js";
+import {lending} from "../lending";
 
 export const getOneWayMarket = (oneWayMarketId: string): OneWayMarketTemplate => {
-    return new OneWayMarketTemplate(oneWayMarketId)
+    const marketData = lending.constants.ONE_WAY_MARKETS[oneWayMarketId];
+    return new OneWayMarketTemplate(oneWayMarketId, marketData)
 }

--- a/src/markets/OneWayMarketTemplate.ts
+++ b/src/markets/OneWayMarketTemplate.ts
@@ -22,7 +22,7 @@ import {
     DIGas,
     smartNumber,
 } from "../utils.js";
-import {IDict, TGas, TAmount, IReward, I1inchRoute, I1inchSwapData} from "../interfaces.js";
+import {IDict, TGas, TAmount, IReward, I1inchRoute, I1inchSwapData, IOneWayMarket} from "../interfaces.js";
 import {
     _getExpected1inch,
     _getSwapData1inch,
@@ -239,9 +239,8 @@ export class OneWayMarketTemplate {
         }
     };
 
-    constructor(id: string) {
+    constructor(id: string, marketData: IOneWayMarket) {
         this.id = id;
-        const marketData = lending.constants.ONE_WAY_MARKETS[id];
         this.name = marketData.name;
         this.addresses = marketData.addresses;
         this.borrowed_token = marketData.borrowed_token;


### PR DESCRIPTION
- Allow initialization OneWayMarketTemplate with market data so we can cache the data in `curve-frontend`
- remove unused code